### PR TITLE
Limit inbound connections for the mongo node.

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,5 +247,4 @@ Some of the items you may want to change:
 
 ### Backlog of features
 * Configure nginx to proxy port 80 traffic to the node app running on 8080
-* Configure the starter node app to point to the private IP address on the mongodb server
 * Format the block storage volume as XFS

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -8,3 +8,5 @@ mnt_group: root
 
 # default device name
 block_device: /dev/sda
+
+mongodb_net_bindip: "{{ hostvars['mongodb-1'].priv_ip_addr }}"

--- a/roles/runstarterapp/tasks/main.yml
+++ b/roles/runstarterapp/tasks/main.yml
@@ -25,7 +25,7 @@
 
 
 - debug: 
-    msg: "exporting variable MONGODB_URI=mongodb://{{ hostvars['mongodb-1'].ansible_host}}:27017/test"
+    msg: "exporting variable MONGODB_URI=mongodb://{{ hostvars['mongodb-1'].priv_ip_addr }}:27017/test"
 
 - debug:
     msg: "starting Web server: open your browser to {{ hostvars['nodejs-1'].ansible_host}} to hit the NGINX server"
@@ -34,7 +34,7 @@
   #- name: Starting app with MONGODB_URI=mongodb://{{ hostvars['mongodb-1'].ansible_eth0.ipv4_secondaries[0].broadcast}}:27017/test
   become: no
   environment:
-    MONGODB_URI: mongodb://{{ hostvars['mongodb-1'].ansible_host}}:27017/test
+    MONGODB_URI: mongodb://{{ hostvars['mongodb-1'].priv_ip_addr }}:27017/test
     #MONGODB_URI: mongodb://{{ hostvars['mongodb-1'].ansible_eth0.ipv4_secondaries[0].broadcast}}:27017/test
     NODE_ENV: production
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -180,7 +180,7 @@ resource "digitalocean_firewall" "mongodb" {
     {
       protocol           = "tcp"
       port_range         = "27017-27019"
-      source_addresses   = ["0.0.0.0/0", "::/0"]
+      source_tags        = ["bp-nodeapp-nodejs"]
     },
   ]
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -28,6 +28,7 @@ resource "digitalocean_droplet" "nodejs" {
   region    = "sfo2"
   size      = "s-1vcpu-1gb"
   monitoring = true
+  private_networking = true
   tags   = ["bp", "bp-nodeapp", "bp-nodeapp-nodejs"]
   ssh_keys  = ["${var.ssh_keys}"]
   user_data = "${file("${path.module}/files/userdata")}"
@@ -76,6 +77,7 @@ resource "ansible_host" "ansible_mongodb" {
 
   vars {
     ansible_host = "${digitalocean_droplet.mongodb.*.ipv4_address[count.index]}"
+    priv_ip_addr = "${digitalocean_droplet.mongodb.*.ipv4_address_private[count.index]}"
   }
 }
 


### PR DESCRIPTION
This PR reconfigures the firewall to only allow inbound connections to the Mongo node from Droplets tagged `bp-nodeapp-nodejs`