### PR TITLE
Added sources for ansible roles in requirements.yml

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,1 +1,4 @@
 #
+- src: jdauphant.nginx
+- src: greendayonfire.mongodb
+- src: geerlingguy.repo-epel


### PR DESCRIPTION
Hi,

when I tried out to use this blueprint I came across an error, when running "bp ansible-playbook setup.yml". The requirements.yml was empty and the ansible roles could not be installed. I added the necessary sources.