### PR TITLE
Change includes to include_tasks and import_tasks

### DIFF
--- a/roles/mongodb/tasks/main.yml
+++ b/roles/mongodb/tasks/main.yml
@@ -8,19 +8,19 @@
     - "{{ ansible_os_family }}.yml"
 
 - name: Include installation tasks
-  include: "install.{{ ansible_os_family | lower }}.yml"
+  import_tasks: "install.{{ ansible_os_family | lower }}.yml"
   tags: [mongodb]
 
 - name: Block storage - format and mount 
-  include: "block-format-and-mount.yml"
+  import_tasks: "block-format-and-mount.yml"
   tags: [mongodb]
 
 - name: Include configuration.yml
-  include: configure.yml
+  import_tasks: configure.yml
   tags: [mongodb]
 
 - name: Include replication and auth configuration
-  include: replication_init_auth.yml
+  import_tasks: replication_init_auth.yml
   when: ( mongodb_replication_replset
         and mongodb_replication_replset != ''
         and mongodb_security_authorization == 'enabled'
@@ -28,7 +28,7 @@
   tags: [mongodb]
 
 - name: Include replication configuration
-  include: replication.yml
+  import_tasks: replication.yml
   when: mongodb_replication_replset and mongodb_replication_replset != ''
   tags: [mongodb]
 
@@ -47,7 +47,7 @@
   tags: [mongodb]
 
 - name: Include authorization configuration
-  include: auth_initialization.yml
+  import_tasks: auth_initialization.yml
   when: ( mongodb_security_authorization == 'enabled'
           and (not mongodb_replication_replset
           or mongodb_replication_replset == '')
@@ -93,6 +93,6 @@
   tags: [mongodb]
 
 - name: Include MMS Agent configuration
-  include: mms-agent.yml
+  import_tasks: mms-agent.yml
   when: mongodb_mms_api_key != ""
   tags: [mongodb]

--- a/roles/mongodb/tasks/main.yml
+++ b/roles/mongodb/tasks/main.yml
@@ -8,7 +8,7 @@
     - "{{ ansible_os_family }}.yml"
 
 - name: Include installation tasks
-  import_tasks: "install.{{ ansible_os_family | lower }}.yml"
+  include_tasks: "install.{{ ansible_os_family | lower }}.yml"
   tags: [mongodb]
 
 - name: Block storage - format and mount 

--- a/roles/mongodb/tasks/replication_init_auth.yml
+++ b/roles/mongodb/tasks/replication_init_auth.yml
@@ -16,7 +16,7 @@
   register: mongodb_replica_init
   ignore_errors: true
 
-- include: auth_initialization.yml
+- import_tasks: auth_initialization.yml
   when: mongodb_replica_init|failed
 
 - name: Replication configuration | 2nd Pt

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -6,36 +6,36 @@
     - "../vars/empty.yml"
   tags: [always]
 
-- include: selinux.yml
+- import_tasks: selinux.yml
   when: ansible_selinux and ansible_selinux.status == "enabled"
   tags: [packages, selinux, nginx]
 
-- include: nginx-official-repo.yml
+- import_tasks: nginx-official-repo.yml
   when: nginx_official_repo == True
   tags: [packages, nginx]
 
-- include: installation.packages.yml
+- import_tasks: installation.packages.yml
   when: nginx_installation_type == "packages"
   tags: [packages, nginx]
 
-- include: ensure-dirs.yml
+- import_tasks: ensure-dirs.yml
   tags: [configuration, nginx]
 
-- include: remove-defaults.yml
+- import_tasks: remove-defaults.yml
   when: not keep_only_specified
   tags: [configuration, nginx]
 
-- include: remove-extras.yml
+- import_tasks: remove-extras.yml
   when: keep_only_specified
   tags: [configuration, nginx]
 
-- include: remove-unwanted.yml
+- import_tasks: remove-unwanted.yml
   tags: [configuration, nginx]
 
-- include: configuration.yml
+- import_tasks: configuration.yml
   tags: [configuration, nginx]
 
-- include: cloudflare_configuration.yml
+- import_tasks: cloudflare_configuration.yml
   when: nginx_set_real_ip_from_cloudflare == True
   tags: [configuration, nginx]
 

--- a/roles/nodejs/tasks/main.yml
+++ b/roles/nodejs/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
-- include: setup-RedHat.yml
+- import_tasks: setup-RedHat.yml
   when: ansible_os_family == 'RedHat'
 
-- include: setup-Debian.yml
+- import_tasks: setup-Debian.yml
   when: ansible_os_family == 'Debian'
 
 - name: Define nodejs_install_npm_user


### PR DESCRIPTION
Ansible is deprecating the bare `includes` format for tasks since it can refer to either static or dynamic includes.  Instead, you can use `include_tasks` and `import_tasks` for dynamic and static task inclusion respectively.  This PR will remove some warnings that you get when running the `site.yml` playbook in its current iteration.