### PR TITLE
Remove duplicate definition of `nginx_configs` in the Nginx role

### DIFF
--- a/roles/nginx/defaults/main.yml
+++ b/roles/nginx/defaults/main.yml
@@ -58,7 +58,6 @@ nginx_configs:
 nginx_remove_sites: []
 nginx_disabled_sites: []
 
-nginx_configs: {}
 nginx_snippets: {}
 nginx_stream_configs: {}
 nginx_remove_configs: []


### PR DESCRIPTION
The `nginx_configs` variable is set twice in
`roles/nginx/default/main.yml`, with the second one (empty) overwriting
the first.  Removed the second one so that the custom config could take
effect.