### PR TITLE
Pin the example app version so that dependencies do not shift

### DIFF
--- a/roles/runstarterapp/defaults/main.yml
+++ b/roles/runstarterapp/defaults/main.yml
@@ -1,7 +1,8 @@
 # defaults file for runstarterapp
 ---
 git_repo_name: sahat/hackathon-starter
-git_repo_url: https://github.com/sahat/hackathon-starter.git
+git_repo_url: "https://github.com/{{ git_repo_name }}.git"
+git_repo_version: "5.0.0"
 git_repo_ssh_private_key: false
 git_repo_ssh_public_key: false
 git_repo_command: false

--- a/roles/runstarterapp/tasks/main.yml
+++ b/roles/runstarterapp/tasks/main.yml
@@ -1,7 +1,12 @@
 # clone the repository
 
 - name: clone node boilerplate app from public git repository 
-  git: repo={{ git_repo_url }} dest=/usr/local/{{ project_folder_name }} force=yes accept_hostkey=yes
+  git:
+    repo: "{{ git_repo_url }}"
+    dest: "/usr/local/{{ project_folder_name }}"
+    version: "{{ git_repo_version }}"
+    force: yes
+    accept_hostkey: yes
   become: no
 
 - name: npm install based on package.json in /usr/local/{{ project_folder_name }} 


### PR DESCRIPTION
The git task in the `runstarterapp` role currently just pulls in from master, which means the dependencies and functionality can shift unpredictably as changes are made to the upstream repository.  This commit pins the version to 5.0.0.