### PR TITLE
Set Node version to comply with new app requirements

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -10,3 +10,5 @@ mnt_group: root
 block_device: /dev/sda
 
 mongodb_net_bindip: "{{ hostvars['mongodb-1'].priv_ip_addr }}"
+
+nodejs_version: "8.x"


### PR DESCRIPTION
Version 5.0.0 of the example app, which we want to pin, requires Node version 8.0 or greater.  This overrides the Node role's default version to install from the later series.