### PR TITLE
Add awareness of current Node app state and set up restart functionality

### DIFF
--- a/roles/runstarterapp/tasks/main.yml
+++ b/roles/runstarterapp/tasks/main.yml
@@ -28,6 +28,14 @@
 #- debug:
 #    msg: "Private IP of mongoDB server: {{ hostvars['mongodb-1'].ansible_eth0.ipv4_secondaries[0].broadcast}}"
 
+- name: Check if App is already running
+  become: no
+  command: pm2 show node-app
+  failed_when: false
+  args:
+    chdir: "/usr/local/{{ project_folder_name }}"
+  register: app_running
+
 - debug: 
     msg: "exporting variable MONGODB_URI=mongodb://{{ hostvars['mongodb-1'].priv_ip_addr }}:27017/test"
 
@@ -38,6 +46,26 @@
     MONGODB_URI: mongodb://{{ hostvars['mongodb-1'].priv_ip_addr }}:27017/test
     NODE_ENV: production
   command: pm2 start app.js --name node-app
+  args:
+    chdir: /usr/local/{{ project_folder_name }}
+  when: app_running.rc == 1
+
+- name: Restarting App server on {{ hostvars['nodejs-1'].ansible_host}}:8080
+  become: no
+  environment:
+    MONGODB_URI: mongodb://{{ hostvars['mongodb-1'].priv_ip_addr }}:27017/test
+    NODE_ENV: production
+  command: pm2 restart node-app
+  args:
+    chdir: /usr/local/{{ project_folder_name }}
+  when: app_running.rc != 1
+
+- name: Generate autostart script for App
+  become: no
+  environment:
+    MONGODB_URI: mongodb://{{ hostvars['mongodb-1'].priv_ip_addr }}:27017/test
+    NODE_ENV: production
+  command: pm2 startup systemd
   args:
     chdir: /usr/local/{{ project_folder_name }}
 


### PR DESCRIPTION
Two issues with the app deployment were:

* It wouldn't restart automatically if the server was restarted
* The playbook would fail on a second pass since it tried to start and
already running application.

This commit checks application state to start or restart as needed and
uses the `pm2` startup script generator to create a configuration to
start the application automatically on boot.